### PR TITLE
Update install-configure.md

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -201,6 +201,12 @@ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.
 </div>
 </div>
 
+## Initialize Your Provider
+
+```console
+kubectl crossplane install provider crossplane/provider-aws:alpha
+```
+
 ## Select a Getting Started Configuration
 
 Crossplane goes beyond simply modelling infrastructure primitives as custom


### PR DESCRIPTION
### Description of your changes

I tried to follow the docs for 1.1.1 and when I tried to run the ProviderConfig example, the CRDs for the Provider were not available.  Looking back at the 0.14 docs, there was a step to add the Provider CRDs before doing the ProviderConfig.  Just put a placeholder in the docs.